### PR TITLE
Fix crash on later versions of AndroidX

### DIFF
--- a/runtime-permission/src/main/java/com/github/florent37/runtimepermission/PermissionFragment.java
+++ b/runtime-permission/src/main/java/com/github/florent37/runtimepermission/PermissionFragment.java
@@ -25,7 +25,7 @@ public class PermissionFragment extends Fragment {
     private PermissionListener listener;
 
     public PermissionFragment() {
-        setRetainInstance(true);
+
     }
 
     public static PermissionFragment newInstance(List<String> permissions) {


### PR DESCRIPTION
Fixes #25 
Fixes #26 

`setRetainInstance(true)` crashes apps using `androidx.core` when they move into the background.

I posted a hacky workaround on [this issue](https://github.com/florent37/RuntimePermission/issues/25#issuecomment-488956845) that involves manually setting retainInstance to false after you ask for permissions.

Note: Everything still appears to be functioning correctly with retain instance set to false. However I am not aware of the what the original intent was of setting the fragment this way, so I can't guarantee there won't be side-effects. I figured it was to prevent unnecessary re-initialisation on configuration changes, but I may be wrong.

Further explanation of the crash can be found in [this stackoverflow answer.](https://stackoverflow.com/a/54104362/10715642)